### PR TITLE
Enable historyApiFallback

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ module.exports = {
     devServer: {
         inline: true,
         contentBase: './src',
+        historyApiFallback: true,
         port: 3000
     },
     module: {


### PR DESCRIPTION
To avoid "cannot GET" error when refreshing a page.
